### PR TITLE
Hotfix - Token refresh and debugging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = streamers
-version = 1.2.8
+version = 1.2.9
 author = Nate Gibson
 author_email = natebgibson@gmail.com
 description = A CLI tool to see who you follow on twitch is streaming and watch them.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = streamers
-version = 1.2.7
+version = 1.2.8
 author = Nate Gibson
 author_email = natebgibson@gmail.com
 description = A CLI tool to see who you follow on twitch is streaming and watch them.

--- a/streamers/streamers.py
+++ b/streamers/streamers.py
@@ -326,7 +326,10 @@ def main():
     player_config = session_vars(config, args)
 
     query_ok, query_status, streams = query_streams(config)
-
+    logging.debug(f"Init query results:\
+                  \nQuery_ok:\n\t{query_ok}\
+                  \nquery_status: \n\t{query_status}\
+                  \nstreams: \n\t{streams}")
     if not query_ok:
         logging.debug("Attempting token refresh.")
         refresh_token(config_filepath, config)

--- a/streamers/streamers.py
+++ b/streamers/streamers.py
@@ -330,7 +330,7 @@ def main():
     if not query_ok:
         logging.debug("Attempting token refresh.")
         refresh_token(config_filepath, config)
-        streams = query_streams(config)
+        query_ok, query_status, streams = query_streams(config)
 
     # region logging
     debug_lines = [
@@ -352,6 +352,7 @@ def main():
         if player_config["playerFlag"]:
             player_selection(player_config, streams)
     else:
-        print(f"Error getting stream data. Response code: {query_status}")
+        print(f"Error getting stream data. Response code: {query_status} \n \
+              Please verify your values in the config file and try again.")
 
 # endregion

--- a/streamers/streamers.py
+++ b/streamers/streamers.py
@@ -2,6 +2,7 @@
 
 # region honeydo_list
 
+# TODO: Add version argparse flag
 # TODO: See if the onbolarding process can be somewhat autoamted
 # TODO: See if there is a way to make config file changes backwards compatible
 # TODO: Look into making table display customizable in terms of size (auto sizing based on window size?) or colums sortable via config file
@@ -186,13 +187,12 @@ def refresh_token(config_path: Path, config: ConfigParser) -> None:
         "client_id": config["TwitchBits"]["clientID"],
         "client_secret": config["TwitchBits"]["clientSecret"]
     }
-    logging.debug(f"Config data: \n {data}")
     r = requests.post(
         "https://id.twitch.tv/oauth2/token",
         headers=headers,
         data=data
     )
-    logging.debug(f"Response JSON: \n{r.json()}")
+    logging.debug(f"Response JSON: \n\t{r.json()}")
     config.set("TwitchBits", "access_token", r.json()["access_token"])
     with open(config_path, "w", encoding="utf-8") as config_file:
         config.write(config_file)
@@ -330,6 +330,7 @@ def main():
                   \nQuery_ok:\n\t{query_ok}\
                   \nquery_status: \n\t{query_status}\
                   \nstreams: \n\t{streams}")
+
     if not query_ok:
         logging.debug("Attempting token refresh.")
         refresh_token(config_filepath, config)
@@ -358,4 +359,9 @@ def main():
         print(f"Error getting stream data. Response code: {query_status} \n \
               Please verify your values in the config file and try again.")
 
+
 # endregion
+
+# Added to enable debugging without having to make file changes.
+if __name__ == "__main__":
+    main()

--- a/streamers/streamers.py
+++ b/streamers/streamers.py
@@ -190,7 +190,7 @@ def refresh_token(config_path: Path, config: ConfigParser) -> None:
     r = requests.post(
         "https://id.twitch.tv/oauth2/token",
         headers=headers,
-        json=data
+        data=data
     )
     logging.debug(f"Response JSON: \n{r.json()}")
     config.set("TwitchBits", "access_token", r.json()["access_token"])


### PR DESCRIPTION
Turns out there was a load bearing change during the mass string refactor pass. That particular change has been reverted. Additionally more debugging lines have been added alongside the ability to debug the script without making line changes for a QOL change for VSCode users.