### PR TITLE
Fix KeyboardInterrupt traceback when stopping player

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = streamers
-version = 1.4.0
+version = 1.4.1
 author = Nate Gibson
 author_email = natebgibson@gmail.com
 description = A CLI tool to see who you follow on twitch is streaming and watch them.

--- a/streamers/streamers.py
+++ b/streamers/streamers.py
@@ -299,7 +299,10 @@ def start_player(stream: str, player_config: Dict[str, Any]) -> bool:
             logging.debug(
                 f"Starting {player_config['player']} with command: {' '.join(cmd)}"
             )
-            subprocess.run(cmd)
+            try:
+                subprocess.run(cmd)
+            except KeyboardInterrupt:
+                print()
         else:
             print(f"{player_config['player']} is not currently supported at this time")
             return False


### PR DESCRIPTION
Catch KeyboardInterrupt during subprocess.run to exit cleanly on Ctrl+C. Bump version to 1.4.1.